### PR TITLE
Renamed lock / unlock method to avoid collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ That's it!
 Now you can start locking and unlocking models:
 
 ```php
-$invoice->lock();
-$invoice->unlock();
+$invoice->markLocked();
+$invoice->markUnlocked();
 
 $invoice->isLocked();    // true or false
 ```

--- a/src/Concerns/Lockable.php
+++ b/src/Concerns/Lockable.php
@@ -47,11 +47,16 @@ trait Lockable
         return $this->isDirty($this->getLockColumn()) && $this->getAttribute($this->getLockColumn()) === false;
     }
 
-    public function setLocked(bool $state): self
+    public function setLocked(bool $state = true): self
     {
         $this->setAttribute($this->getLockColumn(), $state);
 
         return $this;
+    }
+
+    public function setUnlocked(): self
+    {
+        return $this->setLocked(false);
     }
 
     public function markLocked(): self
@@ -63,7 +68,7 @@ trait Lockable
 
     public function markUnlocked(): self
     {
-        $this->setLocked(false)->save();
+        $this->setUnlocked()->save();
 
         return $this;
     }

--- a/src/Contracts/IsLockable.php
+++ b/src/Contracts/IsLockable.php
@@ -13,6 +13,8 @@ interface IsLockable
 
     public function setLocked(bool $state): self;
 
+    public function setUnlocked(): self;
+
     public function markLocked(): self;
 
     public function markUnlocked(): self;

--- a/src/Contracts/IsLockable.php
+++ b/src/Contracts/IsLockable.php
@@ -11,9 +11,11 @@ interface IsLockable
 
     public function isUnlocked(): bool;
 
-    public function lock(): self;
+    public function setLocked(bool $state): self;
 
-    public function unlock(): self;
+    public function markLocked(): self;
+
+    public function markUnlocked(): self;
 
     public function whileLocked(callable $callback): self;
 

--- a/tests/LockableTest.php
+++ b/tests/LockableTest.php
@@ -82,10 +82,10 @@ class LockableTest extends TestCase
     {
         $model = User::create(['name' => 'Lock and Unlock Me', 'locked' => false]);
 
-        $model->lock();
+        $model->markLocked();
         $this->assertTrue($model->fresh()->isLocked());
 
-        $model->unlock();
+        $model->markUnlocked();
         $this->assertTrue($model->fresh()->isUnlocked());
     }
 


### PR DESCRIPTION
The lock method already exists on Eloquent via the query builder.

lock() has become markLocked()
unlock() has become markUnlocked()

This also adds a setLocked method for convenience.